### PR TITLE
处理页面底部许可格式化效果问题

### DIFF
--- a/startup/templates/inc/footer.ejs
+++ b/startup/templates/inc/footer.ejs
@@ -1,6 +1,6 @@
         <div id="footer">
             <div id="footer-inner">
-                <p id="copyright">Copyright (c) <%= site.copyright.beginYear %>-<%= site.copyright.endYear %> <%= site.copyright.owner %></p>
+                <p id="copyright">Copyright (c) <%= site.copyright.beginYear %>-<%= site.copyright.endYear %> <%- site.copyright.owner %></p>
             </div>
         </div>
         <% include footer_plugin %>


### PR DESCRIPTION
直接粘贴许可的html内容时标签符号会被转义